### PR TITLE
Rewrite sprite management

### DIFF
--- a/client/core/src/com/cyberbot/bomberman/controllers/TextureController.java
+++ b/client/core/src/com/cyberbot/bomberman/controllers/TextureController.java
@@ -1,0 +1,74 @@
+package com.cyberbot.bomberman.controllers;
+
+import com.badlogic.gdx.graphics.g2d.Sprite;
+import com.badlogic.gdx.graphics.g2d.SpriteBatch;
+import com.cyberbot.bomberman.models.Drawable;
+import com.cyberbot.bomberman.models.EntitySpritePair;
+import com.cyberbot.bomberman.models.TileSpritePair;
+import com.cyberbot.bomberman.models.Updatable;
+import com.cyberbot.bomberman.models.entities.Entity;
+import com.cyberbot.bomberman.models.factories.SpriteFactory;
+import com.cyberbot.bomberman.models.tiles.Tile;
+import com.cyberbot.bomberman.models.tiles.TileMap;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public class TextureController implements Drawable, Updatable, GameStateController.ChangeListener, TileMap.ChangeListener {
+    private final List<EntitySpritePair> entities;
+    private final List<TileSpritePair> base;
+    private final List<TileSpritePair> floor;
+    private final List<TileSpritePair> walls;
+
+    public TextureController(TileMap map) {
+        map.addListener(this);
+        this.entities = new ArrayList<>();
+        this.base = TileSpritePair.fromTileLayer(map.getBase());
+        this.floor = TileSpritePair.fromTileLayer(map.getFloor());
+        this.walls = TileSpritePair.fromTileLayer(map.getWalls());
+    }
+
+    @Override
+    public void draw(SpriteBatch batch) {
+        base.forEach(pair -> pair.draw(batch));
+        floor.forEach(pair -> pair.draw(batch));
+        walls.forEach(pair -> pair.draw(batch));
+        entities.forEach(pair -> pair.draw(batch));
+    }
+
+    @Override
+    public void update(float delta) {
+        entities.forEach(pair -> pair.update(delta));
+    }
+
+    @Override
+    public void onEntityAdded(Entity entity) {
+        Sprite sprite = SpriteFactory.createSprite(entity);
+        entities.add(new EntitySpritePair(entity, sprite));
+    }
+
+    @Override
+    public void onEntityRemoved(Entity entity) {
+        EntitySpritePair pair = entities.stream()
+                .filter(p -> p.getEntity().equals(entity))
+                .findFirst()
+                .orElseThrow(() -> new RuntimeException("Entity not present in TextureController"));
+        pair.dispose();
+        entities.remove(pair);
+    }
+
+    @Override
+    public void onWallAdded(Tile tile) {
+        walls.add(new TileSpritePair(tile));
+    }
+
+    @Override
+    public void onWallRemoved(Tile tile) {
+        TileSpritePair pair = walls.stream()
+                .filter(p -> p.getTile().equals(tile))
+                .findFirst()
+                .orElseThrow(() -> new RuntimeException("WallTile not present in TextureController"));
+        pair.dispose();
+        walls.remove(pair);
+    }
+}

--- a/client/core/src/com/cyberbot/bomberman/models/EntitySpritePair.java
+++ b/client/core/src/com/cyberbot/bomberman/models/EntitySpritePair.java
@@ -1,0 +1,45 @@
+package com.cyberbot.bomberman.models;
+
+import com.badlogic.gdx.graphics.Texture;
+import com.badlogic.gdx.graphics.g2d.Sprite;
+import com.badlogic.gdx.graphics.g2d.SpriteBatch;
+import com.badlogic.gdx.math.Vector2;
+import com.badlogic.gdx.utils.Disposable;
+import com.cyberbot.bomberman.models.entities.Entity;
+
+public class EntitySpritePair implements Updatable, Drawable, Disposable {
+    private final Entity entity;
+    private final Sprite sprite;
+
+    public EntitySpritePair(Entity entity, Sprite sprite) {
+        this.entity = entity;
+        this.sprite = sprite;
+    }
+
+    public Entity getEntity() {
+        return entity;
+    }
+
+    public Sprite getSprite() {
+        return sprite;
+    }
+
+    @Override
+    public void update(float delta) {
+        Vector2 position = entity.getPosition();
+        sprite.setPosition(position.x - sprite.getWidth() / 2, position.y - sprite.getHeight() / 2);
+    }
+
+    @Override
+    public void draw(SpriteBatch batch) {
+        sprite.draw(batch);
+    }
+
+    @Override
+    public void dispose() {
+        Texture texture = sprite.getTexture();
+        if (texture != null) {
+            texture.dispose();
+        }
+    }
+}

--- a/client/core/src/com/cyberbot/bomberman/models/TileSpritePair.java
+++ b/client/core/src/com/cyberbot/bomberman/models/TileSpritePair.java
@@ -1,0 +1,48 @@
+package com.cyberbot.bomberman.models;
+
+import com.badlogic.gdx.graphics.Texture;
+import com.badlogic.gdx.graphics.g2d.Sprite;
+import com.badlogic.gdx.graphics.g2d.SpriteBatch;
+import com.badlogic.gdx.math.Vector2;
+import com.badlogic.gdx.utils.Disposable;
+import com.cyberbot.bomberman.models.factories.SpriteFactory;
+import com.cyberbot.bomberman.models.tiles.Tile;
+import com.cyberbot.bomberman.models.tiles.TileMapLayer;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+public class TileSpritePair implements Drawable, Disposable {
+    private final Tile tile;
+    private final Sprite sprite;
+
+    public TileSpritePair(Tile tile) {
+        this.tile = tile;
+        this.sprite = SpriteFactory.createSprite(tile);
+
+        Vector2 position = tile.getPosition();
+        this.sprite.setPosition(position.x, position.y);
+    }
+
+
+    @Override
+    public void dispose() {
+        Texture texture = sprite.getTexture();
+        if(texture != null) {
+            texture.dispose();
+        }
+    }
+
+    @Override
+    public void draw(SpriteBatch batch) {
+        sprite.draw(batch);
+    }
+
+    public static List<TileSpritePair> fromTileLayer(TileMapLayer layer) {
+        return layer.stream().map(TileSpritePair::new).collect(Collectors.toList());
+    }
+
+    public Tile getTile() {
+        return tile;
+    }
+}

--- a/client/core/src/com/cyberbot/bomberman/models/Updatable.java
+++ b/client/core/src/com/cyberbot/bomberman/models/Updatable.java
@@ -1,0 +1,5 @@
+package com.cyberbot.bomberman.models;
+
+public interface Updatable {
+    void update(float delta);
+}

--- a/client/core/src/com/cyberbot/bomberman/models/defs/BombDef.java
+++ b/client/core/src/com/cyberbot/bomberman/models/defs/BombDef.java
@@ -1,0 +1,5 @@
+package com.cyberbot.bomberman.models.defs;
+
+public class BombDef {
+    public float detonationTime;
+}

--- a/client/core/src/com/cyberbot/bomberman/models/defs/PlayerDef.java
+++ b/client/core/src/com/cyberbot/bomberman/models/defs/PlayerDef.java
@@ -1,0 +1,7 @@
+package com.cyberbot.bomberman.models.defs;
+
+public class PlayerDef {
+    public float dragModifier;
+    public float maxSpeedModifier;
+    public int textureVariant;
+}

--- a/client/core/src/com/cyberbot/bomberman/models/entities/BombEntity.java
+++ b/client/core/src/com/cyberbot/bomberman/models/entities/BombEntity.java
@@ -1,60 +1,23 @@
 package com.cyberbot.bomberman.models.entities;
 
-import com.badlogic.gdx.Gdx;
-import com.badlogic.gdx.graphics.Texture;
-import com.badlogic.gdx.graphics.g2d.Sprite;
 import com.badlogic.gdx.physics.box2d.BodyDef;
 import com.badlogic.gdx.physics.box2d.CircleShape;
 import com.badlogic.gdx.physics.box2d.FixtureDef;
 import com.badlogic.gdx.physics.box2d.World;
+import com.cyberbot.bomberman.models.defs.BombDef;
 
 public class BombEntity extends Entity {
+    private BombDef def;
 
-    private float detonationTime = 3;
-    private float range = 3;
-    private float power = 1;
-
+    private float timeLeft;
     private boolean blown;
 
-    public BombEntity(World world, String atlasPath) {
+    public BombEntity(World world, BombDef def) {
         super(world);
+        this.def = def;
 
-        sprite = new Sprite(new Texture("bomb.png"));
-        blown = false;
-    }
-
-    public float getDetonationTime() {
-        return detonationTime;
-    }
-
-    public float getRange() {
-        return range;
-    }
-
-    public float getPower() {
-        return power;
-    }
-
-    public void setDetonationTime(float detonationTime) {
-        if(detonationTime < 0) throw new IllegalArgumentException("Detonation time must be < 0");
-
-        this.detonationTime = detonationTime;
-    }
-
-    public void setRange(float range) {
-        if(range < 0) throw new IllegalArgumentException("Bomb range must be < 0");
-
-        this.range = range;
-    }
-
-    public void setPower(float power) {
-        if(power <= 0) throw new IllegalArgumentException("Bomb power must be <= 0");
-
-        this.power = power;
-    }
-
-    public boolean isBlown() {
-        return blown;
+        this.timeLeft = def.detonationTime;
+        this.blown = false;
     }
 
     @Override
@@ -78,12 +41,17 @@ public class BombEntity extends Entity {
         shape.dispose();
     }
 
-    @Override
     public void update(float delta) {
-        super.update(delta);
+        if(timeLeft > 0) {
+            timeLeft = Math.max(timeLeft - delta, 0);
+        }
 
-        detonationTime -= delta;
-        Gdx.app.log("bomberman", "Bomb time left: " + detonationTime + "s");
-        if(detonationTime <= 0) blown = true;
+        if(!blown && timeLeft == 0) {
+            blown = true;
+        }
+    }
+
+    public boolean isBlown() {
+        return blown;
     }
 }

--- a/client/core/src/com/cyberbot/bomberman/models/entities/Entity.java
+++ b/client/core/src/com/cyberbot/bomberman/models/entities/Entity.java
@@ -1,43 +1,24 @@
 package com.cyberbot.bomberman.models.entities;
 
-import com.badlogic.gdx.graphics.g2d.Sprite;
-import com.badlogic.gdx.graphics.g2d.SpriteBatch;
 import com.badlogic.gdx.math.Vector2;
 import com.badlogic.gdx.physics.box2d.Body;
 import com.badlogic.gdx.physics.box2d.World;
 import com.badlogic.gdx.utils.Disposable;
-import com.cyberbot.bomberman.models.Drawable;
 
 import static com.cyberbot.bomberman.utils.Constants.PPM;
 
-public abstract class Entity implements Drawable, Disposable {
+public abstract class Entity implements Disposable {
     protected Body body;
-    protected Sprite sprite;
-    private final World world;
 
     public Entity(World world) {
-        this.world = world;
         createBody(world);
     }
 
     public abstract void createBody(World world);
 
     @Override
-    public void draw(SpriteBatch batch) {
-        sprite.draw(batch);
-    }
-
-    public void update(float delta) {
-        Vector2 position = getPosition();
-        sprite.setPosition(position.x - sprite.getWidth() / 2, position.y - sprite.getHeight() / 2);
-    }
-
-    @Override
     public void dispose() {
-        world.destroyBody(body);
-
-        if(sprite.getTexture() != null)
-            sprite.getTexture().dispose();
+        body.getWorld().destroyBody(body);
     }
 
     public void setPosition(Vector2 position) {

--- a/client/core/src/com/cyberbot/bomberman/models/entities/PlayerEntity.java
+++ b/client/core/src/com/cyberbot/bomberman/models/entities/PlayerEntity.java
@@ -8,6 +8,7 @@ import com.badlogic.gdx.math.Vector2;
 import com.badlogic.gdx.physics.box2d.BodyDef;
 import com.badlogic.gdx.physics.box2d.CircleShape;
 import com.badlogic.gdx.physics.box2d.World;
+import com.cyberbot.bomberman.models.defs.PlayerDef;
 import com.cyberbot.bomberman.screens.GameScreen;
 
 import static com.cyberbot.bomberman.utils.Constants.PPM;
@@ -15,111 +16,44 @@ import static com.cyberbot.bomberman.utils.Constants.PPM;
 public class PlayerEntity extends Entity {
     private static final float ANIMATION_DURATION = 0.2f;
 
-    private final TextureRegion standingBack;
-    private final TextureRegion standingFront;
-    private final TextureRegion standingSide;
-
-    private final Animation<TextureRegion> movingFront;
-    private final Animation<TextureRegion> movingBack;
-    private final Animation<TextureRegion> movingSide;
-    private final TextureAtlas atlas;
-
     private PlayerState currentState;
     private PlayerState previousState;
 
     private LookingDirection verticalDirection;
     private LookingDirection horizontalDirection;
 
-    private float stateTimer;
-    private GameScreen screen;
-    private World world;
+    private PlayerDef def;
 
-    // TODO: Create PlayerDef to hold these and Inventory
-    private float dragModifier;
-    private float maxSpeedModifier;
-
-    public PlayerEntity(World world, String atlasPath) {
+    public PlayerEntity(World world, PlayerDef def) {
         super(world);
-
-        atlas = new TextureAtlas("textures/bomberman_player.atlas");
 
         currentState = PlayerState.STANDING;
         previousState = PlayerState.STANDING;
         verticalDirection = LookingDirection.RIGHT;
         horizontalDirection = null;
-        stateTimer = 0;
-
-        standingBack = atlas.findRegion("standing_back");
-        standingFront = atlas.findRegion("standing_front");
-        standingSide = atlas.findRegion("standing_side");
-
-        movingFront = new Animation<>(ANIMATION_DURATION, atlas.findRegions("moving_front"));
-        movingBack = new Animation<>(ANIMATION_DURATION, atlas.findRegions("moving_back"));
-        movingSide = new Animation<>(ANIMATION_DURATION, atlas.findRegions("moving_side"));
-
-        sprite = new Sprite(standingSide);
+        this.def = def;
     }
 
     public float getDragModifier() {
-        return dragModifier;
+        return def.dragModifier;
     }
 
     public void setDragModifier(float dragModifier) {
-        this.dragModifier = dragModifier;
+        def.dragModifier = dragModifier;
     }
 
     public float getMaxSpeedModifier() {
-        return maxSpeedModifier;
+        return def.maxSpeedModifier;
     }
 
     public void setMaxSpeedModifier(float maxSpeedModifier) {
-        this.maxSpeedModifier = maxSpeedModifier;
+        def.maxSpeedModifier = maxSpeedModifier;
     }
 
-    public void setGameScreenAndWorld(GameScreen gameScreen, World world) {
-        screen = gameScreen;
-        this.world = world;
+    public int getTextureVariant() {
+        return def.textureVariant;
     }
 
-    @Override
-    public void update(float delta) {
-        super.update(delta);
-
-        sprite.setRegion(getFrame(delta));
-    }
-
-    private TextureRegion getFrame(float delta) {
-        TextureRegion frameRegion;
-
-        currentState = getState();
-        switch (currentState) {
-            case MOVING_BACK:
-                frameRegion = movingBack.getKeyFrame(stateTimer, true);
-                break;
-            case MOVING_FRONT:
-                frameRegion = movingFront.getKeyFrame(stateTimer, true);
-                break;
-            case MOVING_SIDE:
-                frameRegion = movingSide.getKeyFrame(stateTimer, true);
-                break;
-            case STANDING:
-            default:
-                if (verticalDirection == null) {
-                    if (horizontalDirection == LookingDirection.UP) frameRegion = standingBack;
-                    else frameRegion = standingFront;
-                } else frameRegion = standingSide;
-        }
-
-        if (verticalDirection == LookingDirection.LEFT && !frameRegion.isFlipX())
-            frameRegion.flip(true, false);
-        else if (verticalDirection == LookingDirection.RIGHT && frameRegion.isFlipX())
-            frameRegion.flip(true, false);
-
-        stateTimer = currentState == previousState ? stateTimer + delta : 0;
-        previousState = currentState;
-
-        return frameRegion;
-    }
 
     private PlayerState getState() {
         if (getVelocity().x == 0 && getVelocity().y == 0)
@@ -176,12 +110,6 @@ public class PlayerEntity extends Entity {
         body.createFixture(shape, 1);
         body.setUserData(this);
         shape.dispose();
-    }
-
-    @Override
-    public void dispose() {
-        super.dispose();
-        atlas.dispose();
     }
 
     public enum PlayerState {

--- a/client/core/src/com/cyberbot/bomberman/models/factories/SpriteFactory.java
+++ b/client/core/src/com/cyberbot/bomberman/models/factories/SpriteFactory.java
@@ -1,0 +1,32 @@
+package com.cyberbot.bomberman.models.factories;
+
+import com.badlogic.gdx.graphics.Texture;
+import com.badlogic.gdx.graphics.g2d.Sprite;
+import com.cyberbot.bomberman.models.entities.BombEntity;
+import com.cyberbot.bomberman.models.entities.Entity;
+import com.cyberbot.bomberman.models.entities.PlayerEntity;
+import com.cyberbot.bomberman.models.tiles.Tile;
+import com.cyberbot.bomberman.utils.Atlas;
+
+public class SpriteFactory {
+    public static Sprite createSprite(Tile tile) {
+        return Atlas.getInstance().createSprite(tile.getTextureName());
+    }
+
+    public static Sprite createSprite(Entity entity) {
+        if(entity instanceof PlayerEntity) {
+            return forPlayer((PlayerEntity) entity);
+        }
+
+        if(entity instanceof BombEntity) {
+            return Atlas.getInstance().createSprite("DynamiteStatic");
+        }
+
+        return null;
+    }
+
+    private static Sprite forPlayer(PlayerEntity player) {
+        // TODO: Implement animations and texture variants
+        return new Sprite(new Texture("./textures/player.png"));
+    }
+}

--- a/client/core/src/com/cyberbot/bomberman/models/tiles/FloorTile.java
+++ b/client/core/src/com/cyberbot/bomberman/models/tiles/FloorTile.java
@@ -1,16 +1,15 @@
 package com.cyberbot.bomberman.models.tiles;
 
-import com.badlogic.gdx.graphics.g2d.Sprite;
 import com.badlogic.gdx.maps.MapProperties;
 import com.badlogic.gdx.math.Vector2;
 
 import java.util.InvalidPropertiesFormatException;
 
-public class FloorTile extends BaseTile {
+public class FloorTile extends Tile {
     private final Properties properties;
 
-    public FloorTile(Sprite texture, Vector2 position, Properties properties) {
-        super(texture, position);
+    public FloorTile(String textureName, Vector2 position, Properties properties) {
+        super(textureName, position);
         this.properties = properties;
     }
 

--- a/client/core/src/com/cyberbot/bomberman/models/tiles/PhysicalTile.java
+++ b/client/core/src/com/cyberbot/bomberman/models/tiles/PhysicalTile.java
@@ -1,17 +1,17 @@
 package com.cyberbot.bomberman.models.tiles;
 
-import com.badlogic.gdx.graphics.g2d.Sprite;
 import com.badlogic.gdx.math.Vector2;
 import com.badlogic.gdx.physics.box2d.Body;
 import com.badlogic.gdx.physics.box2d.BodyDef;
 import com.badlogic.gdx.physics.box2d.World;
+import com.badlogic.gdx.utils.Disposable;
 
-public abstract class PhysicalTile extends BaseTile {
+public abstract class PhysicalTile extends Tile implements Disposable {
     protected Body body;
     private World world;
 
-    public PhysicalTile(World world, Vector2 position, Sprite sprite) {
-        super(sprite, position);
+    public PhysicalTile( String textureName, Vector2 position, World world) {
+        super(textureName, position);
         this.world = world;
 
         position.add(0.5F, 0.5F);
@@ -30,6 +30,5 @@ public abstract class PhysicalTile extends BaseTile {
     @Override
     public void dispose() {
         world.destroyBody(body);
-        sprite.getTexture().dispose();
     }
 }

--- a/client/core/src/com/cyberbot/bomberman/models/tiles/Tile.java
+++ b/client/core/src/com/cyberbot/bomberman/models/tiles/Tile.java
@@ -1,20 +1,15 @@
 package com.cyberbot.bomberman.models.tiles;
 
-import com.badlogic.gdx.graphics.g2d.Sprite;
-import com.badlogic.gdx.graphics.g2d.SpriteBatch;
 import com.badlogic.gdx.maps.MapProperties;
 import com.badlogic.gdx.maps.tiled.TiledMapTile;
 import com.badlogic.gdx.math.Vector2;
 import com.badlogic.gdx.physics.box2d.World;
-import com.badlogic.gdx.utils.Disposable;
-import com.cyberbot.bomberman.models.Drawable;
-import com.cyberbot.bomberman.utils.Atlas;
 
 import java.util.InvalidPropertiesFormatException;
 
 import static com.cyberbot.bomberman.utils.Constants.PPM;
 
-public class BaseTile implements Drawable, Disposable {
+public class Tile {
     private static final String PROPERTY_TILE_TYPE = "tile_type";
     private static final String PROPERTY_TEXTURE_NAME = "texture";
 
@@ -22,24 +17,15 @@ public class BaseTile implements Drawable, Disposable {
     private static final String TILE_TYPE_WALL = "wall";
     private static final String TILE_TYPE_BASE = "base";
 
-    protected final Sprite sprite;
+    private final String textureName;
+    private final Vector2 position;
 
-    public BaseTile(Sprite sprite, Vector2 position) {
-        this.sprite = sprite;
-        sprite.setPosition(position.x * PPM, position.y * PPM);
+    public Tile(String textureName, Vector2 position) {
+        this.textureName = textureName;
+        this.position = new Vector2(position.x, position.y);
     }
 
-    @Override
-    public void dispose() {
-        sprite.getTexture().dispose();
-    }
-
-    @Override
-    public void draw(SpriteBatch batch) {
-        sprite.draw(batch);
-    }
-
-    public static BaseTile fromMapTile(TiledMapTile tile, World world, Vector2 position)
+    public static Tile fromMapTile(TiledMapTile tile, World world, Vector2 position)
             throws InvalidPropertiesFormatException {
         MapProperties properties = tile.getProperties();
         if (!properties.containsKey(PROPERTY_TILE_TYPE) || !properties.containsKey(PROPERTY_TEXTURE_NAME)) {
@@ -52,25 +38,33 @@ public class BaseTile implements Drawable, Disposable {
 
         String tileType = properties.get(PROPERTY_TILE_TYPE, String.class);
         String textureName = properties.get(PROPERTY_TEXTURE_NAME, String.class);
-        Sprite sprite = Atlas.getInstance().createSprite(textureName);
 
         switch (tileType) {
             case TILE_TYPE_FLOOR: {
                 return new FloorTile(
-                        sprite, position,
+                        textureName, position,
                         FloorTile.Properties.fromMapProperties(properties)
                 );
             }
             case TILE_TYPE_WALL: {
-                return new WallTile(world, position, sprite,
-                        WallTile.Properties.fromMapProperties(properties)
+                return new WallTile(textureName, position,
+                        WallTile.Properties.fromMapProperties(properties),
+                        world
                 );
             }
             case TILE_TYPE_BASE: {
-                return new BaseTile(sprite, position);
+                return new Tile(textureName, position);
             }
         }
 
         throw new IllegalArgumentException("Invalid tile type: " + tileType);
+    }
+
+    public String getTextureName() {
+        return textureName;
+    }
+
+    public Vector2 getPosition() {
+        return new Vector2(position.x * PPM, position.y * PPM);
     }
 }

--- a/client/core/src/com/cyberbot/bomberman/models/tiles/TileMapLayer.java
+++ b/client/core/src/com/cyberbot/bomberman/models/tiles/TileMapLayer.java
@@ -1,18 +1,18 @@
 package com.cyberbot.bomberman.models.tiles;
 
-import com.badlogic.gdx.graphics.g2d.SpriteBatch;
 import com.badlogic.gdx.maps.tiled.TiledMapTileLayer;
 import com.badlogic.gdx.math.Vector2;
 import com.badlogic.gdx.physics.box2d.World;
 import com.badlogic.gdx.utils.Disposable;
-import com.cyberbot.bomberman.models.Drawable;
 
-import java.util.InvalidPropertiesFormatException;
+import java.util.*;
+import java.util.function.Consumer;
+import java.util.stream.Collectors;
 
-public class TileMapLayer implements Drawable, Disposable {
-    private int width;
-    private int height;
-    private BaseTile[][] tiles;
+public class TileMapLayer implements Disposable, Collection<Tile> {
+    private final int width;
+    private final int height;
+    private final Tile[][] tiles;
 
     public TileMapLayer(TiledMapTileLayer mapTileLayer, World world)
             throws InvalidPropertiesFormatException {
@@ -20,7 +20,7 @@ public class TileMapLayer implements Drawable, Disposable {
         width = mapTileLayer.getWidth();
         height = mapTileLayer.getHeight();
 
-        tiles = new BaseTile[width][height];
+        tiles = new Tile[width][height];
         for (int x = 0; x < width; x++) {
             for (int y = 0; y < height; y++) {
                 TiledMapTileLayer.Cell cell = mapTileLayer.getCell(x, y);
@@ -29,30 +29,152 @@ public class TileMapLayer implements Drawable, Disposable {
                     continue;
                 }
 
-                tiles[x][y] = BaseTile.fromMapTile(cell.getTile(), world, new Vector2(x, y));
+                tiles[x][y] = Tile.fromMapTile(cell.getTile(), world, new Vector2(x, y));
             }
         }
     }
 
-    public BaseTile getTile(int x, int y) {
+    public Tile getTile(int x, int y) {
         return tiles[x][y];
     }
 
-    @Override
-    public void draw(SpriteBatch batch) {
-        for (int x = 0; x < width; x++) {
-            for (int y = 0; y < height; y++) {
-                if (tiles[x][y] != null) tiles[x][y].draw(batch);
+    Tile removeTile(int x, int y) {
+        Tile tile = getTile(x, y);
+        if (tile != null) {
+            tiles[x][y] = null;
+            if (tile instanceof PhysicalTile) {
+                ((PhysicalTile) tile).dispose();
             }
         }
+
+        return tile;
     }
 
     @Override
     public void dispose() {
         for (int x = 0; x < width; x++) {
             for (int y = 0; y < height; y++) {
-                if (tiles[x][y] != null) tiles[x][y].dispose();
+                if (tiles[x][y] instanceof Disposable) {
+                    ((Disposable) tiles[x][y]).dispose();
+                }
             }
         }
+    }
+
+    @Override
+    public int size() {
+        return getFlatList().size();
+    }
+
+    @Override
+    public boolean isEmpty() {
+        return false;
+    }
+
+    @Override
+    public boolean contains(Object o) {
+        return false;
+    }
+
+    @Override
+    public Iterator<Tile> iterator() {
+        return getFlatList().iterator();
+    }
+
+    @Override
+    public Object[] toArray() {
+        throw new UnsupportedOperationException("");
+    }
+
+    @Override
+    public <T> T[] toArray(T[] a) {
+        throw new UnsupportedOperationException("");
+    }
+
+    @Override
+    public boolean add(Tile tile) {
+        throw new UnsupportedOperationException("");
+    }
+
+    @Override
+    public boolean remove(Object o) {
+        if (o instanceof Tile) {
+            for (int x = 0; x < width; x++) {
+                for (int y = 0; y < height; y++) {
+                    Tile tile = tiles[x][y];
+                    if (o.equals(tile)) {
+                        if (tile instanceof Disposable) {
+                            ((Disposable) tile).dispose();
+                        }
+                        tiles[x][y] = null;
+
+                        return true;
+                    }
+                }
+            }
+        }
+
+        return false;
+    }
+
+    @Override
+    public boolean containsAll(Collection<?> c) {
+        return getFlatList().containsAll(c);
+    }
+
+    @Override
+    public boolean addAll(Collection<? extends Tile> c) {
+        throw new UnsupportedOperationException("Not supported, use TileMapLayer::add(int x, int y)");
+    }
+
+    @Override
+    public boolean removeAll(Collection<?> c) {
+        return c.stream().anyMatch(this::remove);
+    }
+
+    @Override
+    public boolean retainAll(Collection<?> c) {
+        boolean changed = false;
+
+        for (int x = 0; x < width; x++) {
+            for (int y = 0; y < height; y++) {
+                Tile tile = tiles[x][y];
+                if(!c.contains(tile)) {
+                    if (tile instanceof Disposable) {
+                        ((Disposable) tile).dispose();
+                    }
+                    tiles[x][y] = null;
+                    changed = true;
+                }
+            }
+        }
+
+        return changed;
+    }
+
+    @Override
+    public void clear() {
+        for (int x = 0; x < width; x++) {
+            for (int y = 0; y < height; y++) {
+                Tile tile = tiles[x][y];
+                if (tile instanceof Disposable) {
+                    ((Disposable) tile).dispose();
+                }
+                tiles[x][y] = null;
+            }
+        }
+    }
+
+    @Override
+    public void forEach(Consumer<? super Tile> action) {
+        getFlatList().forEach(action);
+    }
+
+    private List<Tile> getFlatList() {
+        return Arrays.stream(tiles)
+                .map(Arrays::asList)
+                .flatMap(List::stream)
+                .filter(Objects::nonNull)
+                .collect(Collectors.toList());
     }
 }

--- a/client/core/src/com/cyberbot/bomberman/models/tiles/WallTile.java
+++ b/client/core/src/com/cyberbot/bomberman/models/tiles/WallTile.java
@@ -1,6 +1,5 @@
 package com.cyberbot.bomberman.models.tiles;
 
-import com.badlogic.gdx.graphics.g2d.Sprite;
 import com.badlogic.gdx.maps.MapProperties;
 import com.badlogic.gdx.math.Vector2;
 import com.badlogic.gdx.physics.box2d.PolygonShape;
@@ -9,8 +8,8 @@ import com.badlogic.gdx.physics.box2d.World;
 public class WallTile extends PhysicalTile {
     private final Properties properties;
 
-    public WallTile(World world, Vector2 position, Sprite sprite, Properties properties) {
-        super(world, position, sprite);
+    public WallTile(String textureName, Vector2 position, Properties properties, World world) {
+        super(textureName, position, world);
         this.properties = properties;
     }
 

--- a/client/core/src/com/cyberbot/bomberman/screens/GameScreen.java
+++ b/client/core/src/com/cyberbot/bomberman/screens/GameScreen.java
@@ -13,14 +13,13 @@ import com.cyberbot.bomberman.Client;
 import com.cyberbot.bomberman.controllers.GameStateController;
 import com.cyberbot.bomberman.controllers.InputController;
 import com.cyberbot.bomberman.controllers.PlayerMovement;
+import com.cyberbot.bomberman.controllers.TextureController;
 import com.cyberbot.bomberman.models.KeyBinds;
-import com.cyberbot.bomberman.models.entities.BombEntity;
-import com.cyberbot.bomberman.models.entities.Entity;
+import com.cyberbot.bomberman.models.defs.PlayerDef;
 import com.cyberbot.bomberman.models.entities.PlayerEntity;
 import com.cyberbot.bomberman.models.tiles.TileMap;
-import com.sun.tools.javac.util.List;
 
-import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.InvalidPropertiesFormatException;
 
 import static com.cyberbot.bomberman.utils.Constants.PPM;
@@ -30,6 +29,7 @@ public class GameScreen extends AbstractScreen {
     private final static int VIEWPORT_HEIGHT = 15;
 
     GameStateController gsc;
+    TextureController txc;
 
     OrthographicCamera camera;
     Viewport viewport;
@@ -53,9 +53,8 @@ public class GameScreen extends AbstractScreen {
         world = new World(new Vector2(0, 0), false);
         b2dr = new Box2DDebugRenderer();
 
-        PlayerEntity player = new PlayerEntity(world, "./textures/player.png");
+        PlayerEntity player = new PlayerEntity(world, new PlayerDef());
         player.setPosition(new Vector2(1.5f * PPM, 1.5f * PPM));
-        player.setGameScreenAndWorld(this, world);
 
         PlayerMovement movementController = new PlayerMovement(player);
         inputController = new InputController(new KeyBinds(), movementController);
@@ -64,7 +63,12 @@ public class GameScreen extends AbstractScreen {
 
         map = new TileMap(world,"./map/bomberman_main.tmx");
 
-        gsc = new GameStateController(map, List.of(player));
+        gsc = new GameStateController(map);
+
+        txc = new TextureController(map);
+        gsc.setListener(txc);
+
+        gsc.addPlayers(Arrays.asList(player));
     }
 
     @Override
@@ -88,6 +92,7 @@ public class GameScreen extends AbstractScreen {
         camera.update();
 
         gsc.update(delta);
+        txc.update(delta);
 
         batch.setProjectionMatrix(camera.combined);
     }
@@ -97,7 +102,7 @@ public class GameScreen extends AbstractScreen {
         super.render(delta);
 
         batch.begin();
-        gsc.draw(batch);
+        txc.draw(batch);
         batch.end();
 
         b2dr.render(world, camera.combined.cpy().scl(PPM));


### PR DESCRIPTION
- Removed any `Texture` or `Sprite` references from `Entities` and `Tiles`
- Drawing handled fully by `TextureController` with change listeners hooked to `GameStateController` and `TileMap`
- Sprites managed by TileSpritePair and EntitySpritePair, allowing easy animation implementation in these classes (separate classes for each Entity)