### PR TITLE
Player death handling

### DIFF
--- a/.idea/misc.xml
+++ b/.idea/misc.xml
@@ -8,6 +8,7 @@
     <option name="languageLevel" value="ES6" />
   </component>
   <component name="LibGDXSkins">
+    <file url="file://$PROJECT_DIR$/client/core/assets/skins/clean-crispy/skin/clean-crispy-ui.json" />
     <file url="file://$PROJECT_DIR$/client/core/assets/skins/skin.json" />
   </component>
   <component name="ProjectPlainTextFileTypeManager">

--- a/client/core/src/com/cyberbot/bomberman/screens/hud/GameHud.java
+++ b/client/core/src/com/cyberbot/bomberman/screens/hud/GameHud.java
@@ -11,7 +11,6 @@ import com.badlogic.gdx.scenes.scene2d.ui.Table;
 import com.badlogic.gdx.utils.Align;
 import com.badlogic.gdx.utils.viewport.Viewport;
 import com.cyberbot.bomberman.core.controllers.WorldChangeListener;
-import com.cyberbot.bomberman.core.models.entities.Entity;
 import com.cyberbot.bomberman.core.models.entities.PlayerEntity;
 import com.cyberbot.bomberman.utils.Atlas;
 
@@ -128,12 +127,7 @@ public class GameHud extends Stage implements WorldChangeListener {
     }
 
     @Override
-    public void onEntityAdded(Entity entity) { }
-
-    @Override
-    public void onEntityRemoved(Entity entity) {
-        if(entity instanceof PlayerEntity && entity.getId() != localPlayerEntity.getId()) {
-            playerListView.onPlayerDeath((PlayerEntity) entity);
-        }
+    public void onPlayerDied(PlayerEntity playerEntity) {
+        playerListView.onPlayerDeath(playerEntity);
     }
 }

--- a/core/src/main/java/com/cyberbot/bomberman/core/controllers/GameStateController.java
+++ b/core/src/main/java/com/cyberbot/bomberman/core/controllers/GameStateController.java
@@ -147,7 +147,7 @@ public final class GameStateController implements Disposable, Updatable, PlayerA
         }
 
         if (other instanceof PlayerEntity) {
-            return; //throw new RuntimeException("Contact detected between two PlayerEntities");
+            return;
         }
 
         handleContact(player, other);
@@ -178,6 +178,10 @@ public final class GameStateController implements Disposable, Updatable, PlayerA
 
     private void onEntityRemoved(Entity entity) {
         listeners.forEach(listener -> listener.onEntityRemoved(entity));
+    }
+
+    private void onPlayerDied(PlayerEntity entity) {
+        listeners.forEach(listener -> listener.onPlayerDied(entity));
     }
 
     private void onBombExploded(BombEntity bomb) {
@@ -263,9 +267,8 @@ public final class GameStateController implements Disposable, Updatable, PlayerA
         ).forEach(playerEntity -> playerEntity.takeDamage(power));
 
         players.stream().filter(PlayerEntity::isDead).forEach(playerEntity -> {
-            playerEntity.markToRemove();
             playerEntity.dispose();
-            onEntityRemoved(playerEntity);
+            onPlayerDied(playerEntity);
         });
     }
 

--- a/core/src/main/java/com/cyberbot/bomberman/core/controllers/GameStateController.java
+++ b/core/src/main/java/com/cyberbot/bomberman/core/controllers/GameStateController.java
@@ -199,13 +199,13 @@ public final class GameStateController implements Disposable, Updatable, PlayerA
 
         TileMapLayer walls = map.getWalls();
 
-        damagePlayers(x, y, (int) (bombPower * 2));
+        damagePlayers(x, y, (bombPower * 2));
 
         // Right
         for (int i = 1; i <= range; i++) {
             Tile tile = walls.getTile(x + i, y);
 
-            damagePlayers(x + i, y, (int) powerRight);
+            damagePlayers(x + i, y, powerRight);
             powerRight = damageTile(tile, powerRight);
             powerRight = Math.max(0, powerRight - bomb.getPowerDropoff());
 
@@ -218,7 +218,7 @@ public final class GameStateController implements Disposable, Updatable, PlayerA
         for (int i = 1; i <= range; i++) {
             Tile tile = walls.getTile(x - i, y);
 
-            damagePlayers(x - i, y, (int) powerLeft);
+            damagePlayers(x - i, y, powerLeft);
             powerLeft = damageTile(tile, powerLeft);
             powerLeft = Math.max(0, powerLeft - bomb.getPowerDropoff());
 
@@ -231,7 +231,7 @@ public final class GameStateController implements Disposable, Updatable, PlayerA
         for (int i = 1; i <= range; i++) {
             Tile tile = walls.getTile(x, y + i);
 
-            damagePlayers(x, y + i, (int) powerUp);
+            damagePlayers(x, y + i, powerUp);
             powerUp = damageTile(tile, powerUp);
             powerUp = Math.max(0, powerUp - bomb.getPowerDropoff());
 
@@ -244,7 +244,7 @@ public final class GameStateController implements Disposable, Updatable, PlayerA
         for (int i = 1; i <= range; i++) {
             Tile tile = walls.getTile(x, y - i);
 
-            damagePlayers(x, y - i, (int) powerDown);
+            damagePlayers(x, y - i, powerDown);
             powerDown = damageTile(tile, powerDown);
             powerDown = Math.max(0, powerDown - bomb.getPowerDropoff());
 
@@ -254,13 +254,14 @@ public final class GameStateController implements Disposable, Updatable, PlayerA
         }
     }
 
-    private void damagePlayers(int x, int y, int power) {
+    private void damagePlayers(int x, int y, float power) {
         players.stream().filter(playerEntity ->
             {
                 Vector2 playerPosition = playerEntity.getPosition();
                 return (Math.floor(playerPosition.x) == x && Math.floor(playerPosition.y) == y);
             }
-        ).forEach(playerEntity -> playerEntity.subtractHp(power));
+        ).forEach(playerEntity -> playerEntity.takeDamage(power));
+
         players.stream().filter(PlayerEntity::isDead).forEach(playerEntity -> {
             playerEntity.markToRemove();
             playerEntity.dispose();

--- a/core/src/main/java/com/cyberbot/bomberman/core/controllers/GameStateController.java
+++ b/core/src/main/java/com/cyberbot/bomberman/core/controllers/GameStateController.java
@@ -62,6 +62,11 @@ public final class GameStateController implements Disposable, Updatable, PlayerA
 
         // Update players
         players.forEach(player -> player.updateFromEnvironment(map));
+
+        players.stream().filter(PlayerEntity::isDead).forEach(playerEntity -> {
+            playerEntity.dispose();
+            onPlayerDied(playerEntity);
+        });
     }
 
     @Override
@@ -265,11 +270,6 @@ public final class GameStateController implements Disposable, Updatable, PlayerA
                 return (Math.floor(playerPosition.x) == x && Math.floor(playerPosition.y) == y);
             }
         ).forEach(playerEntity -> playerEntity.takeDamage(power));
-
-        players.stream().filter(PlayerEntity::isDead).forEach(playerEntity -> {
-            playerEntity.dispose();
-            onPlayerDied(playerEntity);
-        });
     }
 
     /**

--- a/core/src/main/java/com/cyberbot/bomberman/core/controllers/WorldChangeListener.java
+++ b/core/src/main/java/com/cyberbot/bomberman/core/controllers/WorldChangeListener.java
@@ -1,6 +1,7 @@
 package com.cyberbot.bomberman.core.controllers;
 
 import com.cyberbot.bomberman.core.models.entities.Entity;
+import com.cyberbot.bomberman.core.models.entities.PlayerEntity;
 
 /**
  * An interface that any parties interested in changes to the world entities should implement.
@@ -11,12 +12,30 @@ public interface WorldChangeListener {
      *
      * @param entity The new entity.
      */
-    void onEntityAdded(Entity entity);
+    default void onEntityAdded(Entity entity) {
+
+    }
 
     /**
      * Called when an {@link Entity} has been removed from the game.
+     * <p>
+     * Note: This will not be called when a player dies unless it is also removed from the game.
      *
      * @param entity The removed entity.
+     * @see #onPlayerDied(PlayerEntity)
      */
-    void onEntityRemoved(Entity entity);
+    default void onEntityRemoved(Entity entity) {
+
+    }
+
+    /**
+     * Called when a {@link PlayerEntity} has died.
+     * Calls {@link #onEntityRemoved(Entity)} with the given player by default.
+     *
+     * @param playerEntity The player that died entity.
+     * @see #onEntityRemoved(Entity)
+     */
+    default void onPlayerDied(PlayerEntity playerEntity) {
+        onEntityRemoved(playerEntity);
+    }
 }

--- a/core/src/main/java/com/cyberbot/bomberman/core/models/entities/Entity.java
+++ b/core/src/main/java/com/cyberbot/bomberman/core/models/entities/Entity.java
@@ -14,6 +14,7 @@ import static com.cyberbot.bomberman.core.utils.Constants.PPM;
  * Abstract base for all game entities that contain a Box2D body.
  */
 public abstract class Entity implements Disposable, Updatable {
+    private boolean removed;
     private boolean remove;
 
     protected final long id;
@@ -34,7 +35,7 @@ public abstract class Entity implements Disposable, Updatable {
 
     @Override
     public void update(float delta) {
-        if (remove) {
+        if (!removed && remove) {
             dispose();
         }
     }
@@ -42,11 +43,17 @@ public abstract class Entity implements Disposable, Updatable {
     /**
      * Destroys the entity's body.
      *
+     * @throws IllegalStateException If this entity has already been removed.
      * @see World#destroyBody(Body)
      */
     @Override
     public void dispose() {
+        if (removed) {
+            throw new IllegalStateException("This entity has already been removed");
+        }
+
         body.getWorld().destroyBody(body);
+        removed = true;
     }
 
     /**
@@ -87,6 +94,10 @@ public abstract class Entity implements Disposable, Updatable {
 
     public boolean isMarkedToRemove() {
         return remove;
+    }
+
+    public boolean isRemoved() {
+        return removed;
     }
 
     /**

--- a/core/src/main/java/com/cyberbot/bomberman/core/models/entities/PlayerEntity.java
+++ b/core/src/main/java/com/cyberbot/bomberman/core/models/entities/PlayerEntity.java
@@ -52,8 +52,8 @@ public class PlayerEntity extends Entity {
         hp = Math.min(100, hp + value);
     }
 
-    public void subtractHp(int value) {
-        hp = Math.max(0, hp - value);
+    public void takeDamage(float power) {
+        hp = (int) (Math.max(0, hp - power) * inventory.getArmorMultiplier());
     }
 
     public PlayerEntity(World world, PlayerDef def, long id) {

--- a/core/src/main/java/com/cyberbot/bomberman/core/models/items/Upgrade.java
+++ b/core/src/main/java/com/cyberbot/bomberman/core/models/items/Upgrade.java
@@ -6,5 +6,5 @@ package com.cyberbot.bomberman.core.models.items;
 public class Upgrade {
     public static final float MOVEMENT_SPEED_MULTIPLIER = 1.1f;
     public static final float REFILL_SPEED_MULTIPLIER = 1.1f;
-    public static final float ARMOR_MULTIPLIER = 1.1f;
+    public static final float ARMOR_MULTIPLIER = 0.85f;
 }

--- a/core/src/main/java/com/cyberbot/bomberman/core/utils/Constants.java
+++ b/core/src/main/java/com/cyberbot/bomberman/core/utils/Constants.java
@@ -24,7 +24,7 @@ public final class Constants {
     /**
      * How many times per second a snapshot is sent over the network.
      */
-    public static final int TICK_RATE = 20;
+    public static final int TICK_RATE = 60;
 
     public static final int LOBBY_ID_LENGTH = 5;
 }

--- a/core/src/main/java/com/cyberbot/bomberman/core/utils/Utils.java
+++ b/core/src/main/java/com/cyberbot/bomberman/core/utils/Utils.java
@@ -38,18 +38,6 @@ public final class Utils {
         return null;
     }
 
-    public static boolean isSequenceNext(int sequence, int previous) {
-        return isSequenceNext(sequence, previous, Integer.MAX_VALUE / 100);
-    }
-
-    public static boolean isSequenceNext(int sequence, int previous, int maxDrop) {
-        if (Math.abs(sequence - previous) < maxDrop) {
-            return sequence >= previous;
-        } else {
-            return sequence <= previous;
-        }
-    }
-
     public static String generateLobbyId(int length) {
         return RandomStringUtils.randomNumeric(length);
     }

--- a/core/src/main/java/com/cyberbot/bomberman/core/utils/utils.kt
+++ b/core/src/main/java/com/cyberbot/bomberman/core/utils/utils.kt
@@ -4,9 +4,29 @@ import com.github.salomonbrys.kotson.typeToken
 import com.google.gson.Gson
 import com.google.gson.stream.JsonReader
 import java.io.Reader
+import java.util.concurrent.ScheduledExecutorService
+import java.util.concurrent.ScheduledFuture
+import java.util.concurrent.TimeUnit
 
 inline fun <reified T : Any> Gson.fromJsonOrNull(json: Reader): T? = fromJson(json, typeToken<T>())
 
 inline fun <reified T : Any> Gson.fromJsonOrNull(json: String): T? = fromJson(json, typeToken<T>())
 
 inline fun <reified T : Any> Gson.fromJsonOrNull(json: JsonReader): T? = fromJson(json, typeToken<T>())
+
+fun <V, T : ScheduledExecutorService> T.schedule(
+    delay: Long,
+    unit: TimeUnit = TimeUnit.MILLISECONDS,
+    action: () -> V
+): ScheduledFuture<V> {
+    return this.schedule(action, delay, unit)
+}
+
+fun <T : ScheduledExecutorService> T.scheduleAtFixedRate(
+    period: Long,
+    delay: Long = 0,
+    unit: TimeUnit = TimeUnit.MILLISECONDS,
+    action: () -> Unit
+): ScheduledFuture<*> {
+    return this.scheduleAtFixedRate({ action() }, delay, period, unit)
+}

--- a/server/src/main/kotlin/com/cyberbot/bomberman/server/control/ServerService.kt
+++ b/server/src/main/kotlin/com/cyberbot/bomberman/server/control/ServerService.kt
@@ -6,6 +6,7 @@ import com.cyberbot.bomberman.core.models.net.packets.*
 import com.cyberbot.bomberman.core.utils.Utils
 import com.cyberbot.bomberman.server.session.Session
 import com.cyberbot.bomberman.server.session.SessionService
+import com.cyberbot.bomberman.server.session.SessionStateListener
 import org.apache.logging.log4j.kotlin.Logging
 import java.io.IOException
 import java.net.InetSocketAddress
@@ -19,7 +20,7 @@ class ServerService(
     private val lobbyIdLength: Int = 5,
     private val maxPlayersPerLobby: Int = 4,
     private val maxPlayerNickLength: Int = 20
-) : ClientController, Runnable, Logging {
+) : ClientController, Runnable, Logging, SessionStateListener {
     private val sessions = HashMap<String, SessionService>()
     private val clientHandlers = HashMap<Client, ClientControlService>()
     private val registeredClients = ArrayList<Client>() // TODO: Load registered client from file
@@ -61,6 +62,16 @@ class ServerService(
         logger.info { "Client disconnected: ${service.client?.id}" }
         clientHandlers.remove(service.client)
         removeClientFromLobby(service.client)
+    }
+
+    override fun onSessionStarted(session: SessionService) {
+        // TODO: Send control packets to all clients present in the session
+        logger.info { "Started game on session ${session.port}" }
+    }
+
+    override fun onSessionFinished(session: SessionService) {
+        logger.info { "Finished game on session ${session.port}" }
+        sessions.values.remove(session)
     }
 
     private fun onClientRegister(request: ClientRegisterRequest, service: ClientControlService) {
@@ -142,6 +153,7 @@ class ServerService(
         val lobbyId = lobby.id ?: throw RuntimeException("Lobby in lobbies without id")
 
         val session = SessionService()
+        session.listeners.add(this)
         sessions[lobbyId] = session
 
         logger.info { "Staring game on port ${session.port} with ${lobby.clients.size} clients" }

--- a/server/src/main/kotlin/com/cyberbot/bomberman/server/control/ServerService.kt
+++ b/server/src/main/kotlin/com/cyberbot/bomberman/server/control/ServerService.kt
@@ -49,10 +49,10 @@ class ServerService(
     override fun onPacket(payload: ControlPacket, service: ClientControlService) {
         when (payload) {
             is ClientRegisterRequest -> onClientRegister(payload, service)
-            is LobbyCreateRequest -> onLobbyCreate(payload, service)
+            is LobbyCreateRequest -> onLobbyCreate(service)
             is LobbyJoinRequest -> onLobbyJoin(payload, service)
             is LobbyLeaveRequest -> onLobbyLeave(service)
-            is GameStartRequest -> onGameStart(payload, service)
+            is GameStartRequest -> onGameStart(service)
             else -> logger.error { "Unsupported packet type ${payload.javaClass.simpleName}" }
         }
     }
@@ -94,7 +94,7 @@ class ServerService(
         }
     }
 
-    private fun onLobbyCreate(request: LobbyCreateRequest, service: ClientControlService) {
+    private fun onLobbyCreate(service: ClientControlService) {
         service.apply {
             if (lobbies.size < maxLobbyCount) {
                 val lobby = createLobby(client!!)
@@ -137,7 +137,7 @@ class ServerService(
         removeClientFromLobby(service.client)
     }
 
-    private fun onGameStart(request: GameStartRequest, service: ClientControlService) {
+    private fun onGameStart(service: ClientControlService) {
         val lobby = lobbies.values.firstOrNull { it.ownerId == service.client!!.id } ?: return
         val lobbyId = lobby.id ?: throw RuntimeException("Lobby in lobbies without id")
 

--- a/server/src/main/kotlin/com/cyberbot/bomberman/server/session/GameSocket.kt
+++ b/server/src/main/kotlin/com/cyberbot/bomberman/server/session/GameSocket.kt
@@ -6,4 +6,6 @@ import java.net.DatagramPacket
 interface GameSocket {
     @Throws(IOException::class)
     fun send(packet: DatagramPacket)
+
+    fun gameStopped()
 }

--- a/server/src/main/kotlin/com/cyberbot/bomberman/server/session/PlayerSession.kt
+++ b/server/src/main/kotlin/com/cyberbot/bomberman/server/session/PlayerSession.kt
@@ -9,7 +9,7 @@ import com.cyberbot.bomberman.core.models.net.packets.PlayerSnapshotPacket
 import org.apache.commons.collections4.queue.CircularFifoQueue
 import java.util.*
 
-class PlayerSession constructor(val playerEntity: PlayerEntity, queueSize: Int = 32) :
+class PlayerSession constructor(private val playerEntity: PlayerEntity, queueSize: Int = 32) :
     PlayerSnapshotListener, Updatable {
     private val packetQueue: Queue<Pair<Int, Queue<List<Action>>>> = CircularFifoQueue(queueSize)
     private val actionController: PlayerActionController = PlayerActionController(playerEntity)

--- a/server/src/main/kotlin/com/cyberbot/bomberman/server/session/PlayerSession.kt
+++ b/server/src/main/kotlin/com/cyberbot/bomberman/server/session/PlayerSession.kt
@@ -9,7 +9,7 @@ import com.cyberbot.bomberman.core.models.net.packets.PlayerSnapshotPacket
 import org.apache.commons.collections4.queue.CircularFifoQueue
 import java.util.*
 
-class PlayerSession constructor(playerEntity: PlayerEntity, queueSize: Int = 32) :
+class PlayerSession constructor(val playerEntity: PlayerEntity, queueSize: Int = 32) :
     PlayerSnapshotListener, Updatable {
     private val packetQueue: Queue<Pair<Int, Queue<List<Action>>>> = CircularFifoQueue(queueSize)
     private val actionController: PlayerActionController = PlayerActionController(playerEntity)
@@ -28,6 +28,10 @@ class PlayerSession constructor(playerEntity: PlayerEntity, queueSize: Int = 32)
 
     fun addListener(listener: PlayerActionController.Listener) {
         actionController.addListener(listener)
+    }
+
+    fun isPlayerDead(): Boolean {
+        return playerEntity.isDead
     }
 
     override fun update(delta: Float) {

--- a/server/src/main/kotlin/com/cyberbot/bomberman/server/session/Session.kt
+++ b/server/src/main/kotlin/com/cyberbot/bomberman/server/session/Session.kt
@@ -9,27 +9,34 @@ import com.cyberbot.bomberman.core.models.net.packets.GameSnapshotPacket
 import com.cyberbot.bomberman.core.models.net.packets.PlayerSnapshotPacket
 import com.cyberbot.bomberman.core.models.tiles.loader.TileMapFactory
 import com.cyberbot.bomberman.core.utils.Constants
+import com.cyberbot.bomberman.core.utils.scheduleAtFixedRate
 import com.cyberbot.bomberman.server.models.ClientConnection
 import java.io.FileNotFoundException
 import java.io.IOException
 import java.net.DatagramPacket
+import java.util.*
 import java.util.concurrent.ScheduledThreadPoolExecutor
 import java.util.concurrent.TimeUnit
 import java.util.concurrent.locks.ReentrantLock
+import kotlin.collections.HashMap
+import kotlin.concurrent.schedule
 import kotlin.concurrent.withLock
 
-class Session(private val socket: GameSocket) {
+class Session(private val socket: GameSocket, private val gameStopDelay: Long = 5000) {
     private val clientSessions = HashMap<ClientConnection, PlayerSession>()
     private val gameStateController: GameStateController
     private val world: World = World(Vector2(0F, 0F), false)
     private val simulationService = ScheduledThreadPoolExecutor(1)
     private val tickService = ScheduledThreadPoolExecutor(1)
     private var lastUpdate = System.currentTimeMillis()
+    private val worldUpdateLock = ReentrantLock()
+
+    private val worldUpdatedCondition = worldUpdateLock.newCondition()
+
+    var gameFinished = false
+        private set
     var gameStarted: Boolean = false
         private set
-
-    private val worldUpdateLock = ReentrantLock()
-    private val worldUpdatedCondition = worldUpdateLock.newCondition()
 
     init {
         val mapPath = Thread.currentThread().contextClassLoader.getResource("map/bomberman_main.tmx")
@@ -47,8 +54,10 @@ class Session(private val socket: GameSocket) {
 
     fun addClient(connection: ClientConnection, player: PlayerData) {
         check(!gameStarted) { "The game has already started, cannot add clients" }
+
         val playerEntity = player.createEntity(world)
         gameStateController.addPlayer(playerEntity)
+
         val playerSession = PlayerSession(playerEntity)
         clientSessions[connection] = playerSession
         playerSession.addListener(gameStateController)
@@ -98,35 +107,39 @@ class Session(private val socket: GameSocket) {
 
     private fun stopGame() {
         check(gameStarted) { "The game has not yet been started" }
+
         simulationService.shutdown()
         tickService.shutdown()
+
+        simulationService.awaitTermination(500, TimeUnit.MILLISECONDS)
+        tickService.awaitTermination(500, TimeUnit.MILLISECONDS)
+
+        gameStateController.dispose()
+        world.dispose()
+
         socket.gameStopped()
     }
 
     private fun scheduleSimulationUpdates() {
-        simulationService.scheduleAtFixedRate(
-            {
-                try {
-                    val t0 = System.currentTimeMillis()
-                    update((t0 - lastUpdate) / 1000f)
-                    lastUpdate = t0
-                } catch (e: Exception) {
-                    e.printStackTrace()
-                }
-            },
-            0,
-            1000000 / Constants.SIM_RATE.toLong(),
-            TimeUnit.MICROSECONDS
-        )
+        simulationService.scheduleAtFixedRate(1000000L / Constants.SIM_RATE, 0, TimeUnit.MICROSECONDS) {
+            try {
+                val t0 = System.currentTimeMillis()
+                update((t0 - lastUpdate) / 1000f)
+                lastUpdate = t0
+            } catch (e: Exception) {
+                e.printStackTrace()
+            }
+        }
     }
 
     private fun scheduleTickUpdates() {
-        tickService.scheduleAtFixedRate(
-            this::tick,
-            0,
-            1000000 / Constants.TICK_RATE.toLong(),
-            TimeUnit.MICROSECONDS
-        )
+        tickService.scheduleAtFixedRate(1000000L / Constants.TICK_RATE, 0, TimeUnit.MICROSECONDS) {
+            try {
+                tick()
+            } catch (e: Exception) {
+                e.printStackTrace()
+            }
+        }
     }
 
     @Synchronized
@@ -137,13 +150,12 @@ class Session(private val socket: GameSocket) {
         }
 
         clientSessions.values.removeIf { it.isPlayerDead() }
-        if (clientSessions.isEmpty()) {
-            stopGame()
+        if (!gameFinished && clientSessions.isEmpty()) {
+            gameFinished = true
+            Timer().schedule(gameStopDelay) { stopGame() }
         }
 
-        for (session in clientSessions.values) {
-            session.update(delta)
-        }
+        clientSessions.map { it.value }.forEach { it.update(delta) }
         gameStateController.update(delta)
     }
 

--- a/server/src/main/kotlin/com/cyberbot/bomberman/server/session/SessionStateListener.kt
+++ b/server/src/main/kotlin/com/cyberbot/bomberman/server/session/SessionStateListener.kt
@@ -1,0 +1,7 @@
+package com.cyberbot.bomberman.server.session
+
+interface SessionStateListener {
+    fun onSessionStarted(session: SessionService)
+
+    fun onSessionFinished(session: SessionService)
+}


### PR DESCRIPTION
- The game no longer crashes when the player has died
- The server will close the session when all players have died after a delay (5s default)
- Reworked entity removal to be less error prone