### PR TITLE
Fix world simulation locks

### DIFF
--- a/client/core/src/com/cyberbot/bomberman/controllers/NetworkedGameplayController.java
+++ b/client/core/src/com/cyberbot/bomberman/controllers/NetworkedGameplayController.java
@@ -112,7 +112,9 @@ public class NetworkedGameplayController implements Updatable, Drawable, Disposa
         try {
             try {
                 worldUpdateLock.lock();
-                worldUpdatedCondition.await();
+                while (worldController.isWorldLocked()) {
+                    worldUpdatedCondition.await();
+                }
             } finally {
                 worldUpdateLock.unlock();
             }

--- a/core/src/main/java/com/cyberbot/bomberman/core/controllers/LocalWorldController.java
+++ b/core/src/main/java/com/cyberbot/bomberman/core/controllers/LocalWorldController.java
@@ -122,6 +122,10 @@ public class LocalWorldController implements Updatable, Disposable, GameSnapshot
         this.playersAlive = new HashMap<>();
     }
 
+    public boolean isWorldLocked() {
+        return world.isLocked();
+    }
+
     @Override
     public void update(float delta) {
         world.step(delta, 6, 2);

--- a/server/src/main/kotlin/com/cyberbot/bomberman/server/session/Session.kt
+++ b/server/src/main/kotlin/com/cyberbot/bomberman/server/session/Session.kt
@@ -74,7 +74,9 @@ class Session(private val socket: GameSocket, private val gameStopDelay: Long = 
 
     private fun tick() {
         worldUpdateLock.withLock {
-            worldUpdatedCondition.await()
+            while(world.isLocked) {
+                worldUpdatedCondition.await()
+            }
         }
 
         for ((session, packet) in getUpdatePackets()) {
@@ -150,7 +152,6 @@ class Session(private val socket: GameSocket, private val gameStopDelay: Long = 
         }
     }
 
-    @Synchronized
     private fun update(delta: Float) {
         worldUpdateLock.withLock {
             world.step(delta, 6, 2)


### PR DESCRIPTION
Fix race conditions that caused invalid player position during snapshot creation while the world was being simulated